### PR TITLE
Fix a few bugs

### DIFF
--- a/src/m68k/m68k.c
+++ b/src/m68k/m68k.c
@@ -696,6 +696,7 @@ static bool check_interrupts(M68kCpu* cpu) {
         m68k_exception(cpu, vector);
         cpu->sr &= ~0x0700;
         cpu->sr |= (cpu->irq_level << 8);
+        cpu->irq_level = 0;
         cpu->stopped = false;
 
         return true;

--- a/src/m68k/ops_arith.c
+++ b/src/m68k/ops_arith.c
@@ -855,16 +855,31 @@ void m68k_exec_negx(M68kCpu* cpu, u16 opcode) {
         m68k_write_size(cpu, ea.address, result, size);
     }
 
-    bool old_z = (cpu->sr & M68K_SR_Z) != 0;
-    update_flags_sub(cpu, src, 0, result, size);
-
+    u32 msb_mask = (size == SIZE_BYTE) ? 0x80 : (size == SIZE_WORD) ? 0x8000 : 0x80000000;
     u32 value_mask = (size == SIZE_BYTE) ? 0xFF : (size == SIZE_WORD) ? 0xFFFF : 0xFFFFFFFF;
+
+    bool old_z = (cpu->sr & M68K_SR_Z) != 0;
+    cpu->sr &= ~(M68K_SR_N | M68K_SR_Z | M68K_SR_V | M68K_SR_C | M68K_SR_X);
+
+    if (result & msb_mask) cpu->sr |= M68K_SR_N;
+
     if ((result & value_mask) != 0) {
-        cpu->sr &= ~M68K_SR_Z;
+        /* Z is cleared if result is non-zero, otherwise unchanged */
     } else if (old_z) {
         cpu->sr |= M68K_SR_Z;
-    } else {
-        cpu->sr &= ~M68K_SR_Z;
+    }
+
+    /* V: overflow if sign changed unexpectedly.
+     * For 0 - src - X: overflow when src had MSB set and result also has MSB set
+     * (negating the most-negative value), adjusted for the X borrow. */
+    bool sm = (src & msb_mask) != 0;
+    bool rm = (result & msb_mask) != 0;
+    if (sm && rm) cpu->sr |= M68K_SR_V;
+
+    /* C/X: borrow occurred if (masked) src or result has MSB set */
+    if (sm || rm) {
+        cpu->sr |= M68K_SR_C;
+        cpu->sr |= M68K_SR_X;
     }
 }
 

--- a/src/m68k/ops_bit.c
+++ b/src/m68k/ops_bit.c
@@ -162,13 +162,7 @@ void m68k_exec_tas(M68kCpu* cpu, u16 opcode) {
     int reg = opcode & 0x7;
 
     M68kEA ea = m68k_calc_ea(cpu, mode, reg, SIZE_BYTE);
-    u8 data;
-
-    if (ea.is_reg && !ea.is_addr) {
-        data = cpu->d_regs[ea.reg_num].l & 0xFF;
-    } else {
-        data = m68k_read_8(cpu, ea.address);
-    }
+    u8 data = ea.value & 0xFF;
 
     cpu->sr &= ~(M68K_SR_N | M68K_SR_Z | M68K_SR_V | M68K_SR_C);
     if (data == 0) cpu->sr |= M68K_SR_Z;

--- a/src/m68k/ops_logic.c
+++ b/src/m68k/ops_logic.c
@@ -227,7 +227,8 @@ void m68k_exec_clr(M68kCpu* cpu, u16 opcode) {
         return;
     }
 
-    M68kEA ea = m68k_calc_ea_addr(cpu, mode, reg, size);
+    /* MC68000 CLR performs a read-before-write cycle for memory operands */
+    M68kEA ea = m68k_calc_ea(cpu, mode, reg, size);
 
     if (ea.is_reg && !ea.is_addr) {
         u32 mask = (size == SIZE_BYTE) ? 0xFF : (size == SIZE_WORD) ? 0xFFFF : 0xFFFFFFFF;


### PR DESCRIPTION
* Fixed the bug in interrupts that caused CPU starvation.
* Fixed the emulation bugs below:                                                                                                                                          
                                         
  - TAS: remove double memory read for memory operands (use `ea.value`)                                                                                                                     
  - NEGX: fix V/C/X flag computation to account for X borrow
  - CLR: add read-before-write cycle for memory operands (MC68000 behavior) 