### PR TITLE
Update the API for more accurate bus arbitration

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -42,4 +42,6 @@ jobs:
           make install-deps
 
       - name: Run Benchmarks
-        run: make bench
+        run: |
+          BUILD_TYPE=release make all
+          make bench

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ core.*
 site/
 main
 main.exe
+.codex

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ docs: ## Generate project documentation (Doxygen and MkDocs)
 	doxygen Doxyfile
 
 .PHONY: docs-serve
-docs-serve: docs ## Serve Vq MkDocs locally
+docs-serve: docs ## Serve project docs (MkDocs) locally
 	@echo "Serving documentation locally..."
 	python -m http.server --directory ./site
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .rocket68,
-    .version = "0.1.3",
+    .version = "0.2.0",
     .fingerprint = 0x6835a0765ca0de25, // Changing this has security and trust implications.
     .minimum_zig_version = "0.15.2",
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .rocket68,
-    .version = "0.1.2",
+    .version = "0.1.3",
     .fingerprint = 0x6835a0765ca0de25, // Changing this has security and trust implications.
     .minimum_zig_version = "0.15.2",
     .paths = .{

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -168,6 +168,8 @@ All callbacks are per-instance.
 ### `void m68k_set_wait_bus_callback(M68kCpu* cpu, M68kWaitBusCallback callback);`
 
 Called before each memory/fetch bus access.
+The callback receives the 24-bit address, access size, and a write flag, and
+returns extra cycles to deduct for bus contention or wait states.
 
 ### `void m68k_set_int_ack_callback(M68kCpu* cpu, M68kIntAckCallback callback);`
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -94,12 +94,13 @@ void setup_interrupt_demo(M68kCpu* cpu) {
 ```c
 #include "rocket68.h"
 
-static void wait_bus(M68kCpu* cpu, u32 address, M68kSize size) {
+static int wait_bus(M68kCpu* cpu, u32 address, M68kSize size, bool is_write) {
     (void)address;
     (void)size;
+    (void)is_write;
 
     /* Add 2 extra cycles for each bus access. */
-    cpu->cycles_remaining -= 2;
+    return 2;
 }
 
 void attach_wait_states(M68kCpu* cpu) {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,11 +92,12 @@ Use this pattern when your host controls boot flow explicitly.
 ## 5. Callback Wiring (Optional)
 
 ```c
-static void wait_bus(M68kCpu* cpu, u32 address, M68kSize size) {
+static int wait_bus(M68kCpu* cpu, u32 address, M68kSize size, bool is_write) {
     (void)address;
     (void)size;
+    (void)is_write;
     /* Add 2 wait-state cycles for each access */
-    cpu->cycles_remaining -= 2;
+    return 2;
 }
 
 static int int_ack(M68kCpu* cpu, int level) {

--- a/include/m68k.h
+++ b/include/m68k.h
@@ -37,9 +37,17 @@ typedef struct M68kCpu M68kCpu;
 /**
  * @brief Bus wait callback.
  *
- * Called on memory accesses to model wait states.
+ * Called on every memory access (reads, writes, and instruction fetches)
+ * before the access occurs.  Returns the number of extra M68K cycles to
+ * deduct for bus contention or wait states.  Return 0 for no delay.
+ *
+ * @param cpu       CPU context.
+ * @param address   24-bit physical address.
+ * @param size      Operand size (byte, word, or long).
+ * @param is_write  true for write accesses, false for reads and fetches.
+ * @return Extra M68K cycles to deduct (0 = no wait).
  */
-typedef void (*M68kWaitBusCallback)(M68kCpu* cpu, u32 address, M68kSize size);
+typedef int (*M68kWaitBusCallback)(M68kCpu* cpu, u32 address, M68kSize size, bool is_write);
 
 /** @brief INT ACK callback return value for autovector. */
 #define M68K_INT_ACK_AUTOVECTOR 0xffffffff

--- a/include/rocket68.h
+++ b/include/rocket68.h
@@ -14,7 +14,7 @@ extern "C" {
 #include "m68k.h"
 
 /** @brief Rocket 68 semantic version string. */
-#define ROCKET68_VERSION_STR "0.1.2"
+#define ROCKET68_VERSION_STR "0.1.3"
 
 #ifdef __cplusplus
 }

--- a/include/rocket68.h
+++ b/include/rocket68.h
@@ -14,7 +14,7 @@ extern "C" {
 #include "m68k.h"
 
 /** @brief Rocket 68 semantic version string. */
-#define ROCKET68_VERSION_STR "0.1.3"
+#define ROCKET68_VERSION_STR "0.2.0"
 
 #ifdef __cplusplus
 }

--- a/src/m68k/m68k.c
+++ b/src/m68k/m68k.c
@@ -187,14 +187,21 @@ int m68k_ea_cycles(int mode, int reg, M68kSize size) {
     return ea_cycles[idx][size == SIZE_LONG ? 1 : 0];
 }
 
+static inline void apply_wait_bus(M68kCpu* cpu, u32 address, M68kSize size, bool is_write) {
+    if (cpu->wait_bus) {
+        int wait = cpu->wait_bus(cpu, address, size, is_write);
+        if (wait > 0) cpu->cycles_remaining -= wait;
+    }
+}
+
 u8 m68k_read_8(M68kCpu* cpu, u32 address) {
     u32 raw_address = address;
     address = mask_address_24(address);
+    apply_wait_bus(cpu, address, SIZE_BYTE, false);
     if (cpu->read8_cb) {
         return cpu->read8_cb(cpu, address);
     }
     set_fc(cpu, false);
-    if (cpu->wait_bus) cpu->wait_bus(cpu, address, SIZE_BYTE);
     if (is_valid_address(cpu, address)) {
         return cpu->memory[address];
     }
@@ -211,11 +218,11 @@ u8 m68k_read_8(M68kCpu* cpu, u32 address) {
 u16 m68k_read_16(M68kCpu* cpu, u32 address) {
     u32 raw_address = address;
     address = mask_address_24(address);
+    apply_wait_bus(cpu, address, SIZE_WORD, false);
     if (cpu->read16_cb) {
         return cpu->read16_cb(cpu, address);
     }
     set_fc(cpu, false);
-    if (cpu->wait_bus) cpu->wait_bus(cpu, address, SIZE_WORD);
     if ((address & 1) && !cpu->in_address_error) {
         capture_access_fault(cpu, raw_address, false, false);
         cpu->in_address_error = true;
@@ -240,11 +247,11 @@ u16 m68k_read_16(M68kCpu* cpu, u32 address) {
 u32 m68k_read_32(M68kCpu* cpu, u32 address) {
     u32 raw_address = address;
     address = mask_address_24(address);
+    apply_wait_bus(cpu, address, SIZE_LONG, false);
     if (cpu->read32_cb) {
         return cpu->read32_cb(cpu, address);
     }
     set_fc(cpu, false);
-    if (cpu->wait_bus) cpu->wait_bus(cpu, address, SIZE_LONG);
     if ((address & 1) && !cpu->in_address_error) {
         capture_access_fault(cpu, raw_address, false, false);
         cpu->in_address_error = true;
@@ -270,12 +277,12 @@ u32 m68k_read_32(M68kCpu* cpu, u32 address) {
 void m68k_write_8(M68kCpu* cpu, u32 address, u8 value) {
     u32 raw_address = address;
     address = mask_address_24(address);
+    apply_wait_bus(cpu, address, SIZE_BYTE, true);
     if (cpu->write8_cb) {
         cpu->write8_cb(cpu, address, value);
         return;
     }
     set_fc(cpu, false);
-    if (cpu->wait_bus) cpu->wait_bus(cpu, address, SIZE_BYTE);
     if (address < cpu->memory_size) {
         cpu->memory[address] = value;
     } else if (!cpu->in_bus_error) {
@@ -290,12 +297,12 @@ void m68k_write_8(M68kCpu* cpu, u32 address, u8 value) {
 void m68k_write_16(M68kCpu* cpu, u32 address, u16 value) {
     u32 raw_address = address;
     address = mask_address_24(address);
+    apply_wait_bus(cpu, address, SIZE_WORD, true);
     if (cpu->write16_cb) {
         cpu->write16_cb(cpu, address, value);
         return;
     }
     set_fc(cpu, false);
-    if (cpu->wait_bus) cpu->wait_bus(cpu, address, SIZE_WORD);
     if ((address & 1) && !cpu->in_address_error) {
         capture_access_fault(cpu, raw_address, true, false);
         cpu->in_address_error = true;
@@ -319,12 +326,12 @@ void m68k_write_16(M68kCpu* cpu, u32 address, u16 value) {
 void m68k_write_32(M68kCpu* cpu, u32 address, u32 value) {
     u32 raw_address = address;
     address = mask_address_24(address);
+    apply_wait_bus(cpu, address, SIZE_LONG, true);
     if (cpu->write32_cb) {
         cpu->write32_cb(cpu, address, value);
         return;
     }
     set_fc(cpu, false);
-    if (cpu->wait_bus) cpu->wait_bus(cpu, address, SIZE_LONG);
     if ((address & 1) && !cpu->in_address_error) {
         capture_access_fault(cpu, raw_address, true, false);
         cpu->in_address_error = true;
@@ -351,7 +358,7 @@ u16 m68k_fetch(M68kCpu* cpu) {
     set_fc(cpu, true);
     u32 raw_fetch_addr = cpu->pc;
     u32 fetch_addr = mask_address_24(raw_fetch_addr);
-    if (cpu->wait_bus) cpu->wait_bus(cpu, fetch_addr, SIZE_WORD);
+    apply_wait_bus(cpu, fetch_addr, SIZE_WORD, false);
     u16 opcode = 0;
 
     if ((fetch_addr & 1) && !cpu->in_address_error) {

--- a/tests/test_regression.c
+++ b/tests/test_regression.c
@@ -10,12 +10,14 @@ static u32 watched_bus_address = 0;
 static int watched_bus_hits = 0;
 static M68kCpu* nested_exception_cpu = NULL;
 
-static void regression_wait_bus_watch(M68kCpu* cpu, u32 address, M68kSize size) {
+static int regression_wait_bus_watch(M68kCpu* cpu, u32 address, M68kSize size, bool is_write) {
     (void)cpu;
     (void)size;
+    (void)is_write;
     if (address == watched_bus_address) {
         watched_bus_hits++;
     }
+    return 0;
 }
 
 static void regression_nested_exception_cb(M68kCpu* cpu, u32 new_pc) {


### PR DESCRIPTION
* Updated the API for more accurate bus arbitration.
* Updated the API references and examples based on the updated API.
* Updated Rocket 68 version to `0.2.0`.